### PR TITLE
fix: versioning_enabled=true logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ module "my_bucket" {
 | <a name="input_region"></a> [region](#input_region) | Region in which the bucket should be created. Ressource will be created in the region set at the provider level if null. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input_tags) | A list of tags for the bucket. As the Scaleway console does not support key/value tags, tags are written with the format value/value. | `list(string)` | `[]` | no |
 | <a name="input_versioning_enabled"></a> [versioning_enabled](#input_versioning_enabled) | Enable versioning. Once you version-enable a bucket, it can never return to an unversioned state. You can, however, suspend versioning on that bucket. | `bool` | `false` | no |
-| <a name="input_versioning_lock_configuration"></a> [versioning_lock_configuration](#input_versioning_lock_configuration) | Specifies the Object Lock rule for the bucket. Requires versioning. | ```object({ mode = string, days = optional(number), years = optional(number), })``` | ```{ "days": null, "mode": "GOVERNANCE", "years": null }``` | no |
+| <a name="input_versioning_lock_configuration"></a> [versioning_lock_configuration](#input_versioning_lock_configuration) | Specifies the Object Lock rule for the bucket. Requires versioning. | ```object({ mode = optional(string, "GOVERNANCE"), days = optional(number), years = optional(number), })``` | ```{ "days": null, "years": null }``` | no |
 | <a name="input_website_index"></a> [website_index](#input_website_index) | Website Configuration. | `string` | `null` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -54,9 +54,16 @@ resource "scaleway_object_bucket_lock_configuration" "this" {
 
   rule {
     default_retention {
-      mode  = var.versioning_lock_configuration["mode"]
-      days  = var.versioning_lock_configuration["days"]
-      years = var.versioning_lock_configuration["years"]
+      mode  = var.versioning_lock_configuration.mode
+      days  = var.versioning_lock_configuration.days
+      years = var.versioning_lock_configuration.years
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.versioning_enabled ? (var.versioning_lock_configuration.days != null) != (var.versioning_lock_configuration.years != null) : true
+      error_message = "Exactly one of 'days' or 'years' must be provided when versioning is enabled."
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -77,12 +77,11 @@ variable "versioning_enabled" {
 variable "versioning_lock_configuration" {
   description = "Specifies the Object Lock rule for the bucket. Requires versioning."
   type = object({
-    mode  = string,
+    mode  = optional(string, "GOVERNANCE"),
     days  = optional(number),
     years = optional(number),
   })
   default = {
-    mode  = "GOVERNANCE"
     days  = null,
     years = null,
   }


### PR DESCRIPTION
Hello. I started to using this module to create S3 Bucket. I wanted to use versioning but I faced issue. When `versioning_enabled=true` it does not work because changing this value to `true` creates resource `scaleway_object_bucket_lock_configuration` which cannot use default values.

## Demo

When I have:

```hcl
module "s3_bucket" {
  source = "github.com/scaleway-terraform-modules/terraform-scaleway-bucket?ref=v1.0.0"

  name       = "test-bucket-3"
  acl        = "private"
  region     = var.scw_region
  project_id = sensitive(data.bitwarden_secret.scw_project_id.value)
  versioning_enabled = true
}

output "s3_bucket_endpoint" {
  value = module.s3_bucket.bucket_endpoint
}
```

Output is:

```
Error: error creating object bucket (test-bucket-3) lock configuration: operation error S3: PutObjectLockConfiguration, https response error StatusCode: 400, RequestID: XXX, HostID: XXX, api error MalformedXML: The XML you provided was not well-formed or did not validate against our published schema
```


I changed default values:

```hcl
variable "versioning_lock_configuration" {
  description = "Specifies the Object Lock rule for the bucket. Requires versioning."
  type = object({
    mode  = string,
    days  = optional(number),
    years = optional(number),
  })
  default = {
    mode  = "GOVERNANCE"
    days  = 10,
    years = null,
  }
}
```

So when I change `days = null` to `days = 10` then `tofu apply` looks like that:

```
 # module.s3_bucket.scaleway_object_bucket_lock_configuration.this[0] will be created
  + resource "scaleway_object_bucket_lock_configuration" "this" {
      + bucket     = "test-bucket-3"
      + id         = (known after apply)
      + project_id = (sensitive value)
      + region     = (known after apply)

      + rule {
          + default_retention {
              + days = 10
              + mode = "GOVERNANCE"
            }
        }
    }
```

Output: `Apply complete! Resources: 3 added, 0 changed, 0 destroyed.`

Bucket exists and has versioning turned on.

## Summary

Default values in `scaleway_object_bucket_lock_configuration` are not correct. Terraform should validate if value  for `years` or `days` in variable `versioning_lock_configuration` is provided. 

I made some small changes both in resource and variable to validate the value. Right now Terraform validates if user provided `years` or `days` value in `versioning_lock_configuration` variable. If not, `tofu plan` will not work and will show custom output. If value is provided, then it will possible to create bucket with versioning. Default `mode` is still the same (`GOVERNANCE`) but changing this to `COMPLIANCE` is possiblle. 


    
