### PR TITLE
fix: Repair version suspending

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ module "my_bucket" {
 | <a name="input_project_id"></a> [project_id](#input_project_id) | ID of the project the bucket is associated with. If null, ressources will be created in the default project associated with the key. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input_region) | Region in which the bucket should be created. Ressource will be created in the region set at the provider level if null. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input_tags) | A list of tags for the bucket. As the Scaleway console does not support key/value tags, tags are written with the format value/value. | `list(string)` | `[]` | no |
-| <a name="input_versioning_enabled"></a> [versioning_enabled](#input_versioning_enabled) | Enable versioning. Once you version-enable a bucket, it can never return to an unversioned state. You can, however, suspend versioning on that bucket. | `bool` | `false` | no |
-| <a name="input_versioning_lock_configuration"></a> [versioning_lock_configuration](#input_versioning_lock_configuration) | Specifies the Object Lock rule for the bucket. Requires versioning. | ```object({ mode = optional(string, "GOVERNANCE"), days = optional(number), years = optional(number), })``` | ```{ "days": null, "years": null }``` | no |
+| <a name="input_versioning_enabled"></a> [versioning_enabled](#input_versioning_enabled) | Enable versioning. Once you version-enable a bucket, it can never return to an unversioned state. You can, however, suspend versioning on that bucket. **Warning:** This variable is ignored when a lock rule is defined. | `bool` | `false` | no |
+| <a name="input_versioning_lock_configuration"></a> [versioning_lock_configuration](#input_versioning_lock_configuration) | Specifies the Object Lock rule for the bucket. Requires versioning. | ```object({ mode = optional(string, "GOVERNANCE"), days = optional(number), years = optional(number), })``` | `null` | no |
 | <a name="input_website_index"></a> [website_index](#input_website_index) | Website Configuration. | `string` | `null` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 resource "scaleway_object_bucket" "this" {
   force_destroy       = var.force_destroy
   name                = var.name
-  object_lock_enabled = var.versioning_enabled
+  object_lock_enabled = var.versioning_lock_configuration != null ? true : false
 
   region     = var.region
   project_id = var.project_id
@@ -34,7 +34,7 @@ resource "scaleway_object_bucket" "this" {
   }
 
   versioning {
-    enabled = var.versioning_enabled
+    enabled = var.versioning_enabled || (var.versioning_lock_configuration != null)
   }
 }
 
@@ -47,7 +47,7 @@ resource "scaleway_object_bucket_acl" "this" {
 }
 
 resource "scaleway_object_bucket_lock_configuration" "this" {
-  count = var.versioning_enabled ? 1 : 0
+  count = var.versioning_lock_configuration != null ? 1 : 0
 
   bucket     = scaleway_object_bucket.this.name
   project_id = var.project_id

--- a/variables.tf
+++ b/variables.tf
@@ -69,7 +69,7 @@ variable "tags" {
 }
 
 variable "versioning_enabled" {
-  description = "Enable versioning. Once you version-enable a bucket, it can never return to an unversioned state. You can, however, suspend versioning on that bucket."
+  description = "Enable versioning. Once you version-enable a bucket, it can never return to an unversioned state. You can, however, suspend versioning on that bucket. **Warning:** This variable is ignored when a lock rule is defined."
   type        = bool
   default     = false
 }
@@ -81,10 +81,7 @@ variable "versioning_lock_configuration" {
     days  = optional(number),
     years = optional(number),
   })
-  default = {
-    days  = null,
-    years = null,
-  }
+  default = null
 }
 
 variable "website_index" {


### PR DESCRIPTION
This fix decouples enabling versioning and object locking: It allows to create a bucket with only versioning enabled, and suspending it afterwards.

As versioning is required for locking, it is automatically enabled when a locking rule is defined, ignoring variable `versioning_enabled`.

Fixes #58