### PR TITLE
Allow wildcard in principal policy definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ This repository is used to manage object storage buckets on scaleway using terra
 ```hcl
 module "my_bucket" {
   source  = "scaleway-terraform-modules/bucket/scaleway"
-  version = "0.0.1"
+  version = "~> 1"
 
+  name = "my_bucket"
 }
 ```
 


### PR DESCRIPTION
Hi ! Thanks again for those modules :)

I found myself tweaking the variables to match some examples of Scaleway's Bucket Policy,
more precisely the Principal attribute of the policy: https://www.scaleway.com/en/docs/object-storage/api-cli/bucket-policy/#principal

- **fix(policy): allow wildcard principal**
- **docs(readme): tweak example**

I also took this opportunity to freshen up the example which was still pointing towards [0.0.1](https://github.com/scaleway-terraform-modules/terraform-scaleway-bucket/releases/tag/v0.0.1)

Would you be open to further contributions, such as example implementations in the same vibe of https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/tree/v4.6.0/examples ?